### PR TITLE
update to 8.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyee" %}
-{% set version = "9.0.4" %}
+{% set version = "8.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2770c4928abc721f46b705e6a72b0c59480c4a69c9a83ca0b00bb994f1ea4b32
+  sha256: 5c7e60f8df95710dbe17550e16ce0153f83990c00ef744841b43f371ed53ebea
 
 build:
   number: 0


### PR DESCRIPTION
* set version 8.2.2

This version is required for pyppeteer, which sadly doesn't support version of pyee newer or equal to version 9 ...